### PR TITLE
feat: hide after closing window (macOS)

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use tauri::App;
+use tauri::{App, AppHandle, RunEvent};
 
 #[cfg(mobile)]
 mod mobile;
@@ -29,9 +29,9 @@ impl AppBuilder {
         self
     }
 
-    pub fn run(self) {
+    pub fn run<F: FnMut(&AppHandle, RunEvent) + 'static>(self, callback: F) {
         let setup = self.setup;
-        tauri::Builder::default()
+        let app = tauri::Builder::default()
             .setup(move |app| {
                 if let Some(setup) = setup {
                     (setup)(app)?;
@@ -40,7 +40,9 @@ impl AppBuilder {
                 Ok(())
             })
             .plugin(tauri_plugin_shell::init())
-            .run(tauri::generate_context!())
+            .build(tauri::generate_context!())
             .expect("error while running tauri application");
+
+        app.run(callback)
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
             Ok(())
         })
         .run(move |app_handle, e| match e {
+            #[cfg(target_os = "macos")]
             tauri::RunEvent::WindowEvent {
                 label,
                 event: tauri::WindowEvent::CloseRequested { api, .. },

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,7 +27,20 @@ fn main() {
             .initialization_script(app::INIT_SCRIPT)
             .build()
             .unwrap();
+
             Ok(())
         })
-        .run();
+        .run(move |app_handle, e| match e {
+            tauri::RunEvent::WindowEvent {
+                label,
+                event: tauri::WindowEvent::CloseRequested { api, .. },
+                ..
+            } => {
+                if label == "main" {
+                    app_handle.hide().unwrap();
+                    api.prevent_close();
+                }
+            }
+            _ => (),
+        });
 }

--- a/src-tauri/src/mobile.rs
+++ b/src-tauri/src/mobile.rs
@@ -15,5 +15,5 @@ fn main() {
             .unwrap();
             Ok(())
         })
-        .run();
+        .run(|_, _| {});
 }


### PR DESCRIPTION
This feature is implemented by hiding the application when `WindowEvent::CloseRequested` occurs. (macOS-only)

Closes #3 